### PR TITLE
bump node12 to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ outputs:
   output:
     description: 'data output from the upload file'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/